### PR TITLE
Add user levels and xp gain

### DIFF
--- a/app/src/main/java/com/example/partyapp/PartyApp.kt
+++ b/app/src/main/java/com/example/partyapp/PartyApp.kt
@@ -379,6 +379,7 @@ private fun NavigationGraph(
         composable(route = AppScreen.Scan.name){
             ScanScreen(
                 eventViewModel = eventViewModel,
+                userViewModel = userViewModel,
                 onBackToPrevPage = {
                     navController.navigate(AppScreen.Profile.name) {
                         popUpTo(navController.graph.id) { inclusive = true }

--- a/app/src/main/java/com/example/partyapp/data/entity/User.kt
+++ b/app/src/main/java/com/example/partyapp/data/entity/User.kt
@@ -15,5 +15,5 @@ data class User (
     val password : String,
     val email : String,
     var pfp : String,
-    val exp : Long,
+    var exp : Long,
 )

--- a/app/src/main/java/com/example/partyapp/ui/EventScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/EventScreen.kt
@@ -391,7 +391,8 @@ private fun EventTimeDetail(modifier: Modifier = Modifier) {
                 text = starts,
                 onTimePicked = { h, m ->
                     starts = "%02d:%02d".format(h, m)
-                    updateEvent(event.copy(starts = starts))
+                    ends = "%02d:%02d".format(h + 2, m)
+                    updateEvent(event.copy(starts = starts, ends = ends))
                 }
             )
             Text(text = "-", color = Color.White)

--- a/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
@@ -168,6 +168,9 @@ private fun XpBar() {
 
 @Composable
 private fun UserProfilePic(userViewModel: UserViewModel) {
+    val newPicXp = 10
+    val xpGainedMsg = stringResource(id = R.string.msg_gained_xp, newPicXp)
+    val context = LocalContext.current
     var photoUri: Uri by remember { mutableStateOf(value = Uri.EMPTY) }
     val setImg: (Uri, String) -> Unit = { uri, path ->
         val isFirstTime = user?.pfp == null || user?.pfp == ""
@@ -175,7 +178,8 @@ private fun UserProfilePic(userViewModel: UserViewModel) {
         user!!.pfp = path
         userViewModel.changePfpFromId(user?.id!!, path)
         if (isFirstTime) {
-            userViewModel.addExpToLoggedUser(10)
+            userViewModel.addExpToLoggedUser(newPicXp)
+            Toast.makeText(context, xpGainedMsg, Toast.LENGTH_SHORT).show()
             user = userViewModel.loggedUser
         }
     }

--- a/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
@@ -170,9 +170,14 @@ private fun XpBar() {
 private fun UserProfilePic(userViewModel: UserViewModel) {
     var photoUri: Uri by remember { mutableStateOf(value = Uri.EMPTY) }
     val setImg: (Uri, String) -> Unit = { uri, path ->
+        val isFirstTime = user?.pfp == null || user?.pfp == ""
         photoUri = uri
         user!!.pfp = path
         userViewModel.changePfpFromId(user?.id!!, path)
+        if (isFirstTime) {
+            userViewModel.addExpToUser(user!!, 10)
+            user!!.exp += 10
+        }
     }
 
     Box(

--- a/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
@@ -180,15 +180,18 @@ private fun isLoggedUser(userViewModel: UserViewModel, session: String): Boolean
 
 @Composable
 private fun XpBar() {
+    val userLv = LevelThreshold.getLevelForXp(user?.exp ?: 0).level
     Row(
         modifier = Modifier.padding(top = 15.dp)
     ) {
+        Text(text = "$userLv", color = Color.White)
         LinearProgressIndicator(
-            progress = { 0.5f },
+            progress = { LevelThreshold.getPercentageToNextLevel(user?.exp ?: 0) },
             modifier = Modifier.size(200.dp, 2.5.dp),
             color = Color.White,
             trackColor = Color.DarkGray,
         )
+        Text(text = "${userLv+1}", color = Color.White)
     }
 }
 

--- a/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.partyapp.R
@@ -83,7 +84,9 @@ fun ProfileScreen(
         FloatingActionButton(
             onClick = onQRScanFABClicked,
             backgroundColor = colorScheme.surface,
-            modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp)
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(20.dp)
         ) {
             Icon(
                 imageVector = Icons.Default.QrCodeScanner,
@@ -142,13 +145,17 @@ private fun isLoggedUser(userViewModel: UserViewModel, session: String): Boolean
     else user?.username == session
 }
 
+@Preview
 @Composable
 private fun XpBar() {
     val userLv = LevelThreshold.getLevelForXp(user?.exp ?: 0).level
+    val lblLevel = stringResource(id = R.string.lbl_level)
     Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
         modifier = Modifier.padding(top = 15.dp)
     ) {
-        Text(text = "$userLv", color = Color.White)
+        Text(text = "$lblLevel $userLv", color = Color.White)
         LinearProgressIndicator(
             progress = { LevelThreshold.getPercentageToNextLevel(user?.exp ?: 0) },
             modifier = Modifier.size(200.dp, 2.5.dp),

--- a/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ProfileScreen.kt
@@ -175,8 +175,8 @@ private fun UserProfilePic(userViewModel: UserViewModel) {
         user!!.pfp = path
         userViewModel.changePfpFromId(user?.id!!, path)
         if (isFirstTime) {
-            userViewModel.addExpToUser(user!!, 10)
-            user!!.exp += 10
+            userViewModel.addExpToLoggedUser(10)
+            user = userViewModel.loggedUser
         }
     }
 

--- a/app/src/main/java/com/example/partyapp/ui/ScanScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ScanScreen.kt
@@ -23,17 +23,20 @@ import com.example.partyapp.data.relation.UserScansEventCrossRef
 import com.example.partyapp.ui.components.Scanner
 import com.example.partyapp.ui.theme.Typography
 import com.example.partyapp.viewModel.EventViewModel
+import com.example.partyapp.viewModel.UserViewModel
 import kotlinx.serialization.json.Json
 
 @Composable
 fun ScanScreen(
     eventViewModel: EventViewModel,
+    userViewModel: UserViewModel,
     onBackToPrevPage: () -> Unit,
 ) {
     val context = LocalContext.current
-    val newScanXp = 15
+    val creatorXp = 20
+    val participantXp = 15
     val added = stringResource(id = R.string.added)
-    val xpGainedMsg = stringResource(id = R.string.msg_gained_xp, newScanXp)
+    val xpGainedMsg = stringResource(id = R.string.msg_gained_xp, participantXp)
     var scannedResult by remember { mutableStateOf("") }
     Column(modifier = Modifier.fillMaxSize().padding(20.dp)) {
         Text(
@@ -55,7 +58,9 @@ fun ScanScreen(
                     val crossRef = UserScansEventCrossRef(id = user!!.id, eventId = event.eventId)
                     eventViewModel.addScan(crossRef)
                     Toast.makeText(context, "${event.name} $added", Toast.LENGTH_SHORT).show()
+                    userViewModel.addExpToLoggedUser(participantXp)
                     Toast.makeText(context, xpGainedMsg, Toast.LENGTH_SHORT).show()
+                    userViewModel.addExpToUser(event.creator, creatorXp)
                 } catch (_: Exception) {}
             },
             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/example/partyapp/ui/ScanScreen.kt
+++ b/app/src/main/java/com/example/partyapp/ui/ScanScreen.kt
@@ -31,7 +31,9 @@ fun ScanScreen(
     onBackToPrevPage: () -> Unit,
 ) {
     val context = LocalContext.current
+    val newScanXp = 15
     val added = stringResource(id = R.string.added)
+    val xpGainedMsg = stringResource(id = R.string.msg_gained_xp, newScanXp)
     var scannedResult by remember { mutableStateOf("") }
     Column(modifier = Modifier.fillMaxSize().padding(20.dp)) {
         Text(
@@ -53,6 +55,7 @@ fun ScanScreen(
                     val crossRef = UserScansEventCrossRef(id = user!!.id, eventId = event.eventId)
                     eventViewModel.addScan(crossRef)
                     Toast.makeText(context, "${event.name} $added", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, xpGainedMsg, Toast.LENGTH_SHORT).show()
                 } catch (_: Exception) {}
             },
             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/example/partyapp/ui/UserLevelHelper.kt
+++ b/app/src/main/java/com/example/partyapp/ui/UserLevelHelper.kt
@@ -30,7 +30,7 @@ enum class LevelThreshold(private val requiredXp: Int, val level: Int) {
             val deltaXp = (nextLevel.requiredXp - currentLevel.requiredXp).toFloat()
             val reducedXp = (xp - currentLevel.requiredXp).toFloat()
             // d : 100 = r : x
-            return reducedXp * 100.0f / deltaXp
+            return reducedXp / deltaXp
         }
     }
 }

--- a/app/src/main/java/com/example/partyapp/ui/UserLevelHelper.kt
+++ b/app/src/main/java/com/example/partyapp/ui/UserLevelHelper.kt
@@ -1,0 +1,36 @@
+package com.example.partyapp.ui
+
+enum class LevelThreshold(private val requiredXp: Int, val level: Int) {
+    LV_0(0, 0),
+    LV_1(100, 1),
+    LV_2(250, 2),
+    LV_3(450, 3),
+    LV_4(750, 4),
+    LV_5(1100, 5),
+    LV_6(1500, 6),
+    LV_7(2000, 7),
+    LV_8(3000, 8),
+    LV_9(4500, 9),
+    LV_10(7000, 10);
+
+    companion object {
+        fun getLevelForXp(xp: Long): LevelThreshold {
+            // Iterate through the levels in reverse order (highest to lowest)
+            for (level in values().reversed()) {
+                if (xp >= level.requiredXp) {
+                    return level
+                }
+            }
+            return LV_0
+        }
+
+        fun getPercentageToNextLevel(xp: Long): Float {
+            val currentLevel = getLevelForXp(xp)
+            val nextLevel = values()[currentLevel.ordinal + 1]
+            val deltaXp = (nextLevel.requiredXp - currentLevel.requiredXp).toFloat()
+            val reducedXp = (xp - currentLevel.requiredXp).toFloat()
+            // d : 100 = r : x
+            return reducedXp * 100.0f / deltaXp
+        }
+    }
+}

--- a/app/src/main/java/com/example/partyapp/ui/components/EventCardComponent.kt
+++ b/app/src/main/java/com/example/partyapp/ui/components/EventCardComponent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
@@ -59,8 +60,10 @@ fun EventCard(
                     AsyncImage(
                         model = user?.pfp ?: event.creator.pfp,
                         contentDescription = stringResource(id = R.string.lbl_creator_pfp),
+                        contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .padding(10.dp, 9.dp)
+                            .size(60.dp)
                             .clip(CircleShape)
                             .background(Color.Black)
                     )

--- a/app/src/main/java/com/example/partyapp/ui/components/LocationPickerComponent.kt
+++ b/app/src/main/java/com/example/partyapp/ui/components/LocationPickerComponent.kt
@@ -110,7 +110,8 @@ fun LocationPicker(
                 if (!addresses.isNullOrEmpty()) {
                     onLocationPicked(addresses[0])
                 }
-            }
+            },
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/com/example/partyapp/viewModel/UserViewModel.kt
+++ b/app/src/main/java/com/example/partyapp/viewModel/UserViewModel.kt
@@ -53,6 +53,13 @@ class UserViewModel @Inject constructor(
         repository.updateExpFromId(user.id, (user.exp + newExp).toString())
     }
 
+    fun addExpToLoggedUser(exp: Int) = viewModelScope.launch {
+        _loggedUser?.let {
+            repository.updateExpFromId(it.id, (it.exp + exp).toString())
+            it.exp += exp
+        }
+    }
+
     suspend fun insertNewUser(user: User) = repository.insertNewUser(user)
     //viewModelScope.launch {
     //    repository.insertNewUser(user)

--- a/app/src/main/java/com/example/partyapp/viewModel/UserViewModel.kt
+++ b/app/src/main/java/com/example/partyapp/viewModel/UserViewModel.kt
@@ -5,10 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.partyapp.data.entity.User
 import com.example.partyapp.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import okhttp3.internal.wait
 import javax.inject.Inject
 
 @HiltViewModel
@@ -50,6 +47,10 @@ class UserViewModel @Inject constructor(
 
     fun updateExpFromId(userId: Int, newExp: String) = viewModelScope.launch {
         repository.updateExpFromId(userId, newExp)
+    }
+
+    fun addExpToUser(user: User, newExp: Int) = viewModelScope.launch {
+        repository.updateExpFromId(user.id, (user.exp + newExp).toString())
     }
 
     suspend fun insertNewUser(user: User) = repository.insertNewUser(user)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="login">Login</string>
     <string name="logo">Logo</string>
     <string name="logout">Logout</string>
+    <string name="msg_gained_xp">You gained %d XP</string>
     <string name="no_description">No description</string>
     <string name="no_location">No location</string>
     <string name="password">Password</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="lbl_event_name">Event name</string>
     <string name="lbl_event_participants">Number of participants</string>
     <string name="lbl_event_time">Event time</string>
+    <string name="lbl_level">LV.</string>
     <string name="lbl_need_login">Already have an account?</string>
     <string name="lbl_need_register">Don\'t have an account yet?</string>
     <string name="lbl_no_added_events">No added events.</string>


### PR DESCRIPTION
Users will now gain xp doing certain actions. As the xp increase, the use will gain levels. There are 10 levels (for now).

Actions that will make the user gain xp:
- Adding a profile picture for the first time
- Creating a new event
- Scanning an event's QR
- Having a user scan your event's QR
